### PR TITLE
Update models.py

### DIFF
--- a/ban/models.py
+++ b/ban/models.py
@@ -6,7 +6,7 @@ class UsersBan(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL,
                              verbose_name="User name",
                              help_text="Choose Username"
-                             on_delete=models.SET_NULL)
+                             on_delete=models.CASCADE)
 
     ban = models.BooleanField(default=False,
                               verbose_name="Ban",


### PR DESCRIPTION
Changed the on_delete option to CASCADE from SET_NULL (i.e. remove ban when the user deletes their account). Also prevents error below error when making migrations:
ban.UsersBan.user: (fields.E320) Field specifies on_delete=SET_NULL, but cannot be null. HINT: Set null=True argument on the field, or change the on_delete rule.